### PR TITLE
Fix mq producer channel leak

### DIFF
--- a/vflow/ipfix.go
+++ b/vflow/ipfix.go
@@ -187,6 +187,7 @@ func (i *IPFIX) shutdown() {
 	// logging and close UDP channel
 	logger.Println("ipfix has been shutdown")
 	close(ipfixUDPCh)
+	close(ipfixMQCh)
 }
 
 func (i *IPFIX) ipfixWorker(wQuit chan struct{}) {


### PR DESCRIPTION
MQ channel is not being closed on shutdown, so producer loop can't be exitied and no graceful shutdown can be performed.